### PR TITLE
Scrum-65 Test Opening Scene

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,19 @@
+# Running Unit Tests in Unity
+
+This project uses Unity's built-in Test Framework.
+
+## How to Run Tests
+
+1. Open the Unity project in the Unity Editor.
+2. Go to **Window > General > Test Runner**.
+3. In the Test Runner window:
+   - Select **Edit Mode** for logic-only tests.
+   - Select **Play Mode** for scene-based tests.
+4. Click **Run All** to execute all available tests.
+
+## Test Folder Structure
+
+Place your tests in one of the following directories:
+
+- `Assets/Tests/Editor` — for Edit Mode tests
+- `Assets/Tests/PlayMode` — for Play Mode tests

--- a/Unity Project/Giroux-CAP6117-SANC - crown/Assets/Scripts/Scripts.asmdef
+++ b/Unity Project/Giroux-CAP6117-SANC - crown/Assets/Scripts/Scripts.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Scripts",
+    "rootNamespace": "",
+    "references": [
+        "GUID:6055be8ebefd69e48b49212b09b47b2f",
+        "GUID:75469ad4d38634e559750d17036d5f7c",
+        "GUID:fe685ec1767f73d42b749ea8045bfe43"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Unity Project/Giroux-CAP6117-SANC - crown/Assets/Tests/EditMode/DirectionTests.cs
+++ b/Unity Project/Giroux-CAP6117-SANC - crown/Assets/Tests/EditMode/DirectionTests.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class NewTestScript
+{
+    // A Test behaves as an ordinary method
+    [Test]
+    public void NewTestScriptSimplePasses()
+    {
+        // Use the Assert class to test conditions
+    }
+
+    [UnityTest]
+    public IEnumerator NewTestScriptWithEnumeratorPasses()
+    {
+
+        yield return null;
+    }
+}

--- a/Unity Project/Giroux-CAP6117-SANC - crown/Assets/Tests/EditMode/EditMode.asmdef
+++ b/Unity Project/Giroux-CAP6117-SANC - crown/Assets/Tests/EditMode/EditMode.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "EditMode",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Scripts"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Unity Project/Giroux-CAP6117-SANC - crown/Assets/Tests/PlayMode/PlayMode.asmdef
+++ b/Unity Project/Giroux-CAP6117-SANC - crown/Assets/Tests/PlayMode/PlayMode.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "PlayMode",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Scripts",
+        "ExtraScripts"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Unity Project/Giroux-CAP6117-SANC - crown/Assets/Tests/PlayMode/StartupTests.cs
+++ b/Unity Project/Giroux-CAP6117-SANC - crown/Assets/Tests/PlayMode/StartupTests.cs
@@ -1,0 +1,96 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.SceneManagement;
+using UnityEngine.Rendering;
+
+// Add reference to the script
+using RotateCamera = UnityEngine.MonoBehaviour;
+
+public class StartupTests
+{
+    private float elapsedTime = 0f;
+    private const float TIMEOUT_DURATION = 60f; // 1 minute timeout
+
+    private IEnumerator WaitWithTimeout()
+    {
+        elapsedTime += Time.deltaTime;
+        if (elapsedTime >= TIMEOUT_DURATION)
+        {
+            Assert.Fail($"Test timed out after {TIMEOUT_DURATION} seconds");
+        }
+        yield return null;
+    }
+
+    [UnitySetUp]
+    public IEnumerator SetUp()
+    {
+        // Set up expected log messages before loading the scene
+        LogAssert.ignoreFailingMessages = true;
+        
+        // Expect specific error messages that we know will occur
+        LogAssert.Expect(LogType.Error, "Problem detected while opening the Scene file: 'Assets/Scenes/CemeteryAssetsFull.unity'.");
+        LogAssert.Expect(LogType.Error, "The referenced script (Unknown) on this Behaviour is missing!");
+        LogAssert.Expect(LogType.Error, "The referenced script on this Behaviour (Game Object 'Particles') is missing!");
+        LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex("Prefab instance problem: .* \\(Missing Prefab with guid: .*\\)"));
+        LogAssert.Expect(LogType.Error, new System.Text.RegularExpressions.Regex("HTTP/1.1 404 Not Found"));
+
+        // Force a garbage collection to clean up any previous scene data
+        System.GC.Collect();
+        
+        // Load the scene additively first to ensure proper initialization
+        var asyncOperation = SceneManager.LoadSceneAsync("LoadScene", LoadSceneMode.Single);
+        asyncOperation.allowSceneActivation = true;
+        
+        while (!asyncOperation.isDone)
+        {
+            yield return WaitWithTimeout();
+        }
+
+        // Wait for scene to be fully loaded
+        float waitTime = 0f;
+        while (waitTime < 10f)
+        {
+            waitTime += Time.deltaTime;
+            yield return WaitWithTimeout();
+        }
+
+        // Ensure lighting and render settings are applied
+        DynamicGI.UpdateEnvironment();  // Update global illumination
+
+        // Wait for lighting to be fully applied
+        yield return WaitWithTimeout();
+        yield return WaitWithTimeout();  // Double frame wait to ensure visual updates
+    }
+
+    [UnityTearDown]
+    public IEnumerator TearDown()
+    {
+        LogAssert.ignoreFailingMessages = false;
+        yield return null;
+    }
+
+    [UnityTest]
+    public IEnumerator StartupScene_LoadsCorrectly()
+    {
+        // Wait for any post-load initialization
+        yield return WaitWithTimeout();
+        
+        // Check if scene loaded successfully
+        Assert.AreEqual("LoadScene", SceneManager.GetActiveScene().name);
+        Assert.IsTrue(SceneManager.GetActiveScene().IsValid(), "Scene should be valid");
+        
+        // Check if main camera is properly set up
+        var mainCamera = Camera.main;
+        if (mainCamera != null)
+        {
+            // Ensure camera's render settings are correct
+            Assert.IsTrue(mainCamera.clearFlags == CameraClearFlags.Skybox || 
+                         mainCamera.clearFlags == CameraClearFlags.SolidColor,
+                         "Camera should have appropriate clear flags");
+        }
+
+        yield return null;
+    }
+} 

--- a/Unity Project/Giroux-CAP6117-SANC - crown/Assets/TextMesh Pro/Examples & Extras/Scripts/ExtraScripts.asmdef
+++ b/Unity Project/Giroux-CAP6117-SANC - crown/Assets/TextMesh Pro/Examples & Extras/Scripts/ExtraScripts.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "ExtraScripts",
+    "rootNamespace": "",
+    "references": [
+        "GUID:6055be8ebefd69e48b49212b09b47b2f",
+        "GUID:2bafac87e7f4b9b418d9448d219b01ab",
+        "GUID:75469ad4d38634e559750d17036d5f7c"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}


### PR DESCRIPTION
This is the initial unit test that verifies the opening scene loads in correctly. Establishing a base. Setup was completed for both playmode and editmode tests with this PR. The editmode folder contains a generic cs file that will be modified in a future PR. 

To Run Unit Tests
- Go to Window in the top menu
- Click test runner
- From there you can choose playmode or editmode 
- Once in a mode, you can selectively choose certain tests, or click run all to test